### PR TITLE
Use NewApexLogServiceContext instead of NewServiceLogContext.

### DIFF
--- a/example/log-to-nsq/log-to-nsq.go
+++ b/example/log-to-nsq/log-to-nsq.go
@@ -104,7 +104,7 @@ func main() {
 	handler := apexovernsq.NewApexLogNSQHandler(protobuf.Marshal, publisher, "log")
 
 	alog.SetHandler(handler)
-	ctx := apexovernsq.NewServiceLogContext()
+	ctx := apexovernsq.NewApexLogServiceContext()
 	ctx.WithFields(alog.Fields{
 		"flavour": "pistachio",
 		"scoops":  "two",


### PR DESCRIPTION
This PR updates the example program to match changes in the function names of the library. 