### PR TITLE
Allow overriding the handler when creating a service context.

### DIFF
--- a/servicelog.go
+++ b/servicelog.go
@@ -15,19 +15,33 @@ func processName() string {
 	return path.Base(os.Args[0])
 }
 
-func NewApexLogServiceContext() *log.Entry {
-
+func appendServiceFieldsToEntry(entry *log.Entry) *log.Entry {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.WithError(err).Warn("Unable to get hostname for service logging")
 	}
-
-	return log.WithFields(
+	return entry.WithFields(
 		log.Fields{
 			"service":  processName(),
 			"hostname": hostname,
 			"pid":      fmt.Sprintf("%d", os.Getpid()),
 		})
+
+}
+
+// Create a new logging context with service information.
+func NewApexLogServiceContext() *log.Entry {
+	logger, _ := log.Log.(*log.Logger)
+	entry := log.NewEntry(logger)
+	return appendServiceFieldsToEntry(entry)
+}
+
+// Create a new logging context, with a handler that isn't the default handler and with service information appended.
+func NewApexLogServiceContextWithHandler(handler log.Handler) *log.Entry {
+	logger, _ := log.Log.(*log.Logger)
+	entry := log.NewEntry(logger)
+	entry.Logger.Handler = handler
+	return appendServiceFieldsToEntry(entry)
 }
 
 type ServiceFilterApexLogHandler struct {

--- a/servicelog_test.go
+++ b/servicelog_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/apex/log/handlers/logfmt"
 	"github.com/apex/log/handlers/memory"
 )
 
@@ -49,6 +50,20 @@ func TestNewServiceLogContext(t *testing.T) {
 	if hostname != expectedHostname {
 		t.Errorf("Expected %q, got %q", expectedHostname, hostname)
 	}
+}
+
+// If we create a new service log context from an existing context,
+// we'll use it's Logger not the default one.
+func TestNewServiceLogContextWithHandler(t *testing.T) {
+	mem := memory.New()
+	lf := logfmt.New(os.Stdout)
+	log.SetHandler(lf)
+	ctx2 := NewApexLogServiceContextWithHandler(mem)
+	_, ok := ctx2.Logger.Handler.(*logfmt.Handler)
+	if ok {
+		t.Fatal("got logfmt handler expected memory handler")
+	}
+
 }
 
 // The ServiceFilterApexLogHandler will let all entries through when the filter is nil.


### PR DESCRIPTION
Because calls to ```github.com/apex/log.SetHandler``` end up setting the targets of a shared pointer, it's useful to create a context that points elsewhere and is resistant to this.  