### PR TITLE
Use time.Time.Equal instead of = operator when comparing timestamps

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -111,7 +111,7 @@ func TestHandleMessage(t *testing.T) {
 	if entry.Level != sourceEntry.Level {
 		t.Errorf("Expected %s, got %s", sourceEntry.Level, entry.Level)
 	}
-	if entry.Timestamp != sourceEntry.Timestamp {
+	if !entry.Timestamp.Equal(sourceEntry.Timestamp) {
 		t.Errorf("Expected %q, got %q", sourceEntry.Timestamp, entry.Timestamp)
 	}
 	expectedFieldCount := len(sourceEntry.Fields)


### PR DESCRIPTION
This PR fixes a failing test.  Essentially I was using the wrong standard of equality for two timestamps. 