### PR TITLE
Create a new Logger rather than overwrite the Handler on the default logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ generates a go library containing a `Marshal` and an `Unmarshal`
 function that can be used by the producing and consuming handlers in
 `apexovernsq`. You'll find these functions by importing
 `github.com/avct/apexovernsq/protobuf`
->>>>>>> 111f09128073ebda85b00be7247f20faf9848edb
+

--- a/servicelog.go
+++ b/servicelog.go
@@ -38,9 +38,11 @@ func NewApexLogServiceContext() *log.Entry {
 
 // Create a new logging context, with a handler that isn't the default handler and with service information appended.
 func NewApexLogServiceContextWithHandler(handler log.Handler) *log.Entry {
-	logger, _ := log.Log.(*log.Logger)
+	logger := &log.Logger{
+		Handler: handler,
+		Level:   log.Log.(*log.Logger).Level,
+	}
 	entry := log.NewEntry(logger)
-	entry.Logger.Handler = handler
 	return appendServiceFieldsToEntry(entry)
 }
 


### PR DESCRIPTION
I noticed today that we're rather hackily overriding the `Handler` in apex's default `Logger` (`log.Log`) within `NewApexLogServiceContextWithHandler`.  To prevent weird interactions (and to make this function more generally useful, I've modified it to create a new `Logger` instead. 