### PR TITLE
Don't block if logChan is full

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -144,7 +144,6 @@ func (h *AsyncApexLogNSQHandler) HandleLog(e *log.Entry) error {
 		backupLogger.Error("AsyncApexLogNSQHandler log channel is full")
 		backupLogger.Handler.HandleLog(e)
 	}
-	h.logChan <- e
 	h.mu.Unlock()
 	return nil
 }

--- a/producer_test.go
+++ b/producer_test.go
@@ -90,7 +90,7 @@ func TestNewAsyncApexLogHandler(t *testing.T) {
 	fakeMarshal := func(x interface{}) ([]byte, error) {
 		return nil, nil
 	}
-	handler := NewAsyncApexLogNSQHandler(fakeMarshal, fakePublish, "testing")
+	handler := NewAsyncApexLogNSQHandler(fakeMarshal, fakePublish, "testing", 2)
 	if handler == nil {
 		t.Fatal("Expected *AsyncApexLogNSQHandler, got nil")
 	}
@@ -110,7 +110,7 @@ func TestAsyncApexLogHandlerSendsMessagesToBePublished(t *testing.T) {
 	fakeMarshal := func(x interface{}) ([]byte, error) {
 		return nil, nil
 	}
-	handler := NewAsyncApexLogNSQHandler(fakeMarshal, fakePublish, "testing")
+	handler := NewAsyncApexLogNSQHandler(fakeMarshal, fakePublish, "testing", 2)
 	log.SetHandler(handler)
 	handler.Stop() // Stop any messages getting consumed
 	log.Info("Log something")
@@ -132,7 +132,7 @@ func TestAsyncApexLogNSQHandlerLogs(t *testing.T) {
 		return nil
 	}
 
-	handler := NewAsyncApexLogNSQHandler(json.Marshal, fakePublish, "testing")
+	handler := NewAsyncApexLogNSQHandler(json.Marshal, fakePublish, "testing", 2)
 	log.SetHandler(handler)
 	log.WithField("user", "tealeg").Info("Hello")
 	var messageCount int


### PR DESCRIPTION
Ensure that the `AsyncApexLogNSQHandler` doesn't block if it's `logChan` channel fills up. 