### PR TITLE
Add caller_func to fields we test for

### DIFF
--- a/producer_test.go
+++ b/producer_test.go
@@ -93,6 +93,12 @@ func TestApexLogNSQHandler(t *testing.T) {
 		t.Fatalf("Expected caller line to be %q, but got %q", expected, callerLine)
 	}
 
+	callerFunc := entry.Fields.Get("caller_func").(string)
+	expected = "github.com/avct/apexovernsq.TestApexLogNSQHandler"
+	if callerFunc != expected {
+		t.Fatalf("Expected caller function to be %q, but got %q", expected, callerFunc)
+	}
+
 }
 
 func TestNewAsyncApexLogHandler(t *testing.T) {


### PR DESCRIPTION
I missed this on a recent PR.